### PR TITLE
本文スタイルの調整

### DIFF
--- a/public/stylesheets/basic.css
+++ b/public/stylesheets/basic.css
@@ -106,6 +106,7 @@
 	padding-left: 10px;
 }
 #cotents h2 {
+	margin-top: 1em;
 	color: #e2d79e;
 	font-size: 32px;
 	line-height: 1.3;
@@ -114,7 +115,7 @@
 }
 #cotents .content {
 	margin-top: 20px;
-	font-size: 22px;
+	font-size: 16px;
 	padding-bottom: 20px;
 	border-bottom-width: 1px;
 	border-bottom-style: dotted;
@@ -184,7 +185,7 @@
 	padding-right: 13px;
 	padding-bottom: 10px;
 	padding-left: 13px;
-	font-size: 20px;
+	font-size: 18px;
 }
 .content code {
 	color: #57EB55;
@@ -193,9 +194,9 @@
 	white-space: -o-pre-wrap;   /* Opera 7 */
 	white-space: pre-wrap;      /* CSS3 */
 	word-wrap: break-word;      /* IE 5.5+ */
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 	line-height: 1.7;
-	font-size: 18px;
+	font-size: 0.9em;
 }
 .content .to_top {
 	font-size: 14px;
@@ -382,7 +383,6 @@
         margin-left: 20px;
 }
 
-.content code {
-        font-size: 0.6em;
-        font-weight: normal;
+.highlight .nt {
+	color: #5d61fd!important;
 }


### PR DESCRIPTION
・末尾の.codeを削除
・contentのfont-sizeを16pxに変更。
・codeのfont-sizeを0.9emに変更。
・codeのfont-familyを変更。font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
・#cotents h2にmargin-top:1emを追加。
・.highlight .ntが黒に埋まっていたので明るめの青に変更(#5d61fd)。
